### PR TITLE
Support for multiple users and API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,13 @@ then click "Service Hooks" followed by "WebHook URLs".  Add a URL for your newly
 
 [Asana API Key]: http://developer.asana.com/documentation/#api_keys
 
+### Multiple users & API keys
+
+To have each developer's commit comments appear as coming from their own Asana account, you can use the ASANA_USERS evironment variable:
+```
+heroku config:add ASANA_USERS='[{"username":"FirstName LastName", "key":"XXXXXXXX.XXXXXXXXXXXXXXXXXX"}, {"username":"FirstName2 LastName2", "key":"XXXXXXXX.XXXXXXXXXXXXXXXXXX"}]'
+```
+
 Commit Syntax
 =============
 When committing, use one of the following verbs followed by an Asana task ID in your commit message (prefixed by a #):

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ then click "Service Hooks" followed by "WebHook URLs".  Add a URL for your newly
 
 To have each developer's commit comments appear as coming from their own Asana account, you can use the ASANA_USERS evironment variable:
 ```
-heroku config:add ASANA_USERS='[{"username":"FirstName LastName", "key":"XXXXXXXX.XXXXXXXXXXXXXXXXXX"}, {"username":"FirstName2 LastName2", "key":"XXXXXXXX.XXXXXXXXXXXXXXXXXX"}]'
+heroku config:add ASANA_USERS='[{"username":"GitHubUsername1", "key":"XXXXXXXX.XXXXXXXXXXXXXXXXXX"}, {"username":"GitHubUsername2", "key":"XXXXXXXX.XXXXXXXXXXXXXXXXXX"}]'
 ```
+You'll need to maintain this map of GitHub usernames and Asana API keys as you add employees, but if a matching GitHub username is not found in `ASANA_USERS` then the `ASANA_KEY` will be used as a fallback.
 
 Commit Syntax
 =============

--- a/lib/github-asana.js
+++ b/lib/github-asana.js
@@ -2,6 +2,7 @@ var util = require('util');
 var request = require('request');
 var asana_key = process.env.ASANA_KEY
 var asana_base_url = 'https://app.asana.com/api/1.0';
+var users = JSON.parse(process.env.ASANA_USERS);
 
 function getCommits(req) {
   var payload;
@@ -53,7 +54,8 @@ function getTaskActions(commits) {
                 
                 // For every matched ID, we attach a 'see' task so there is always a comment (regardless of verbs)
                 tasks.push({
-                    verb:'see'
+                    author: commits[i].author.username
+                    ,verb:'see'
                     ,id:current_id
                     ,message:commits[i].author.username + ' referenced this issue from a commit\n'+commits[i].id.slice(0,7)+' '+commits[i].message+'\n'+commits[i].url
                 });
@@ -66,7 +68,8 @@ function getTaskActions(commits) {
             if (current_id != '' && current_verb != '' && updated_verb_or_id) {
                 if (normalizeVerb(current_verb)!='see') { // We already track every ID with a 'see' verb above
                     tasks.push({
-                        verb:normalizeVerb(current_verb)
+                        author: commits[i].author.username
+                        ,verb:normalizeVerb(current_verb)
                         ,id:current_id
                     });
                 }
@@ -87,9 +90,25 @@ function getTaskActions(commits) {
 }
 
 function sendTaskCommentsToAsana(tasks) {
-  var auth = 'Basic ' + new Buffer(asana_key+":").toString('base64');
+    // change asana user depending on the commit
+  var auths = {};
+  console.dir(users);
+  for (var i = 0; i < users.length; i++) {
+    auths[users[i].username] = 'Basic ' + new Buffer(users[i].key + ":").toString('base64');
+  }
+  var defaultAuth = 'Basic ' + new Buffer(asana_key+":").toString('base64');
+  
   for (var i in tasks) {
     var task = tasks[i];
+    var auth;
+    if (auths[task.author])
+    {
+      auth = auths[task.author];
+    }
+    else
+    {
+      auth = defaultAuth;
+    }
     if (task.verb=='fix') {
         request.put({
             url: asana_base_url+"/tasks/"+task.id, 

--- a/lib/github-asana.js
+++ b/lib/github-asana.js
@@ -92,7 +92,6 @@ function getTaskActions(commits) {
 function sendTaskCommentsToAsana(tasks) {
     // change asana user depending on the commit
   var auths = {};
-  console.dir(users);
   for (var i = 0; i < users.length; i++) {
     auths[users[i].username] = 'Basic ' + new Buffer(users[i].key + ":").toString('base64');
   }


### PR DESCRIPTION
This will allow comments to appear from individual developers. If the author is not found in the ASANA_USERS variable, the ASANA_KEY will be used. As described in the updated `README.md`, the ASANA_USERS variable is formatted as:

``` json
[{"username":"FirstName LastName", "key":"XXXXXXXX.XXXXXXXXXXXXXXXXXX"}, {"username":"FirstName2 LastName2", "key":"XXXXXXXX.XXXXXXXXXXXXXXXXXX"}]
```

This resolves https://github.com/jamieforrest/github-asana/issues/7 and is based on work by @LarsHassler (https://github.com/LarsHassler/github-asana/commit/1399ea805224f1fbdc09299c1c2e85cb0e94cf15)

I haven't done much with javascript, so let me know if you see any issues with this.
