### PR TITLE
Fix bug with ASANA_USERS env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,15 @@ then click "Service Hooks" followed by "WebHook URLs".  Add a URL for your newly
 
 ### Multiple users & API keys
 
-To have each developer's commit comments appear as coming from their own Asana account, you can use the ASANA_USERS evironment variable:
+To have each developer's commit comments appear as coming from their own Asana account, you can use the `ASANA_USERS` environment variable:
 ```
 heroku config:add ASANA_USERS='[{"username":"GitHubUsername1", "key":"XXXXXXXX.XXXXXXXXXXXXXXXXXX"}, {"username":"GitHubUsername2", "key":"XXXXXXXX.XXXXXXXXXXXXXXXXXX"}]'
 ```
-You'll need to maintain this map of GitHub usernames and Asana API keys as you add employees, but if a matching GitHub username is not found in `ASANA_USERS` then the `ASANA_KEY` will be used as a fallback.
+```
+ASANA_USERS='[{"username":"GitHubUsername1", "key":"XXXXXXXX.XXXXXXXXXXXXXXXXXX"}, {"username":"GitHubUsername2", "key":"XXXXXXXX.XXXXXXXXXXXXXXXXXX"}]' node app.js
+```
+
+You'll need to maintain this map of GitHub usernames and Asana API keys as you add employees, but if a matching GitHub username is not found in `ASANA_USERS` or `ASANA_USERS` is not provided then the `ASANA_KEY` will be used as a fallback.
 
 Commit Syntax
 =============

--- a/lib/github-asana.js
+++ b/lib/github-asana.js
@@ -2,7 +2,13 @@ var util = require('util');
 var request = require('request');
 var asana_key = process.env.ASANA_KEY
 var asana_base_url = 'https://app.asana.com/api/1.0';
-var users = JSON.parse(process.env.ASANA_USERS);
+
+var users;
+try {
+  users = JSON.parse(process.env.ASANA_USERS);
+} catch (e) {
+  users = [];
+}
 
 function getCommits(req) {
   var payload;


### PR DESCRIPTION
Sets `users` to an empty array if `process.env.ASANA_USERS` is not defined or is not valid JSON. Also clarified the docs on this. Fixes #15. 
